### PR TITLE
Fix prompt list refresh on save

### DIFF
--- a/prompt_list_node.py
+++ b/prompt_list_node.py
@@ -284,6 +284,8 @@ class NS_PromptList:
                 
                 # Save
                 self._save_yaml(select_yaml, data)
+                # Refresh enums to update key list immediately
+                self.refresh_enums()
                 
             except Exception as e:
                 print(f"Error saving prompt: {e}")


### PR DESCRIPTION
## Summary
- refresh title enums immediately when saving prompts

## Testing
- `python -m py_compile prompt_list_node.py`


------
https://chatgpt.com/codex/tasks/task_e_687ea540b6dc8321aff44316f84eb796